### PR TITLE
feat: Add GitHub Actions workflow for automated deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to OCI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            randintn/novo-pecas-online:${{ github.ref_name }}
+            randintn/novo-pecas-online:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to OCI Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            cd /home/ubuntu/
+            export IMAGE_TAG=${{ github.ref_name }}
+            docker-compose pull
+            docker-compose up -d


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the deployment process.

The workflow is triggered on new tags (e.g., v1.0.0) and consists of two jobs:
1.  **build-and-push:** Builds the Docker image and pushes it to Docker Hub.
2.  **deploy:** Connects to the OCI server via SSH and updates the application using docker-compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated deployment workflow for version releases to container registry and cloud infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->